### PR TITLE
Fixed segfault due to nullptr access

### DIFF
--- a/src/clientinterfacedumper.cpp
+++ b/src/clientinterfacedumper.cpp
@@ -650,6 +650,11 @@ start_of_loop:
                         if (ras.Size() > 8)
                         {
                             int32_t stackOffset = ras.GetOffset();
+                            if (ras[stackOffset - 8] == nullptr)
+                            {
+                                // Nullptr check
+                                goto start_of_loop;
+                            }
                             size_t assertOffset = m_constBase + ras[stackOffset - 8]->disp;
                             if(m_module->IsDataOffset(assertOffset))
                             {

--- a/src/randomstack.cpp
+++ b/src/randomstack.cpp
@@ -169,3 +169,23 @@ void RandomAccessStack::Print() {
         }
     }
 }
+
+void RandomAccessStack::Print(int32_t offset) {
+    std::cout << "Printout of RandomAccessStack offset: " << offset << std::endl;
+    std::map<int32_t, cs_x86*>::iterator stack = m_stack.find(offset);
+
+    if (stack != m_stack.cend() && stack->second != nullptr) {
+        std::cout << "Offset " << stack->first << ", disp: " 
+            << stack->second->disp << " disp offset: " 
+            << (int32_t)stack->second->encoding.disp_offset 
+            << " imm offset: " 
+            << (int32_t)stack->second->encoding.imm_offset 
+            << " imm size: " 
+            << (int32_t)stack->second->encoding.imm_size 
+            << " imm0: " 
+            << (int32_t)stack->second->operands[0].imm 
+            << " imm1: " 
+            << (int32_t)stack->second->operands[1].imm 
+            << std::endl;
+    }
+}

--- a/src/randomstack.h
+++ b/src/randomstack.h
@@ -39,6 +39,11 @@ public:
      * @brief Prints some info about the RandomAccessStack to cout. Can segfault sometimes...
      */
     void Print();
+
+    /**
+     * @brief Prints some info about a single offset in the RandomAccessStack to cout. Can segfault sometimes...
+     */
+    void Print(int32_t offset);
 private:
     int32_t m_offset;
     int32_t m_offsetBackup;


### PR DESCRIPTION
Fixes a segmentation fault due to a nullptr access using a `RandomAccessStack` in `ClientInterfaceDumper::CheckIfAssertCannotCallInCrossProcessFunc`.